### PR TITLE
Refactor ZipCode validator options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  * Add `Ip` constraint.
  * Add `Iban` constraint.
  * Add `Isbn` constraint.
+ * Refactor `ZipCode` to get new countries option. See related PR: [ronanguilloux/IsoCodes#38](https://github.com/ronanguilloux/IsoCodes/pull/38)
 
 * 1.0.4 (2015-06-23)
 

--- a/UPGRADE-1.1.md
+++ b/UPGRADE-1.1.md
@@ -28,3 +28,14 @@ class CustomValidator extends AbstractIsoCodesConstraintValidator
     // ...
 }
 ```
+
+## ZipCode validator country option
+
+ZipCode validator was refactored to get benefit of
+[new country code patterns](https://github.com/ronanguilloux/IsoCodes/blob/1.2.0/src/IsoCodes/ZipCode.php#L27-L203).
+
+Because of that, `Canada`, `France` and `Netherlands` country options are now deprecated.
+
+Use country codes equivalent instead: `CA`, `FR` and `NL`.
+
+The `US` option still the same, but the related constant will be removed in 2.0.

--- a/src/Constraints/ZipCode.php
+++ b/src/Constraints/ZipCode.php
@@ -2,6 +2,7 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use IsoCodes;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -13,13 +14,28 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class ZipCode extends Constraint
 {
+    /**
+     * @deprecated since 1.1, to be removed in 2.0.
+     */
     const US            = 'US';
+    /**
+     * @deprecated since 1.1, to be removed in 2.0.
+     */
     const CANADA        = 'Canada';
+    /**
+     * @deprecated since 1.1, to be removed in 2.0.
+     */
     const FRANCE        = 'France';
+    /**
+     * @deprecated since 1.1, to be removed in 2.0.
+     */
     const NETHERLANDS   = 'Netherlands';
 
     const ALL           = 'all';
 
+    /**
+     * @deprecated since 1.1, to be removed in 2.0.
+     */
     public static $countries = [
         self::US,
         self::CANADA,
@@ -38,8 +54,21 @@ class ZipCode extends Constraint
     {
         parent::__construct($options);
 
-        if ($this->country != self::ALL && !in_array($this->country, self::$countries)) {
-            throw new ConstraintDefinitionException(sprintf('The option "country" must be one of "%s" or "all"', implode('", "', self::$countries)));
+        // 1.0 BC
+        if ($this->country !== 'US' && in_array($this->country, self::$countries, true)) {
+            $deprecatedOptionsBridge = [
+                'Canada'        => 'CA',
+                'France'        => 'FR',
+                'Netherlands'   => 'NL',
+            ];
+
+            trigger_error('The value "'.$this->country.'" for '.__CLASS__.'::country options is deprecated since version 1.1 and will be removed in 2.0. Use '.$deprecatedOptionsBridge[$this->country].' instead.', E_USER_DEPRECATED);
+
+            $this->country = $deprecatedOptionsBridge[$this->country];
+        }
+
+        if ($this->country != self::ALL && !in_array($this->country, IsoCodes\ZipCode::getAvailableCountries())) {
+            throw new ConstraintDefinitionException(sprintf('The option "country" must be one of "%s" or "all"', implode('", "', IsoCodes\ZipCode::getAvailableCountries())));
         }
     }
 }

--- a/src/Constraints/ZipCodeValidator.php
+++ b/src/Constraints/ZipCodeValidator.php
@@ -25,8 +25,8 @@ class ZipCodeValidator extends AbstractIsoCodesConstraintValidator
 
         if ($constraint->country == ZipCode::ALL) {
             $validated = false;
-            foreach (ZipCode::$countries as $country) {
-                if ($this->validateCountry($value, $country)) {
+            foreach (IsoCodes\ZipCode::getAvailableCountries() as $country) {
+                if (IsoCodes\ZipCode::validate($value, $country)) {
                     $validated = true;
                     break;
                 }
@@ -34,28 +34,8 @@ class ZipCodeValidator extends AbstractIsoCodesConstraintValidator
             if ($validated === false) {
                 $this->createViolation($constraint->message);
             }
-        } elseif (!$this->validateCountry($value, $constraint->country)) {
+        } elseif (!IsoCodes\ZipCode::validate($value, $constraint->country)) {
             $this->createViolation($constraint->message);
         }
-    }
-
-    /**
-     * @deprecated To be removed when bumping requirements to ronanguilloux/isocodes ~1.2
-     *
-     * @param mixed  $value
-     * @param string $country
-     *
-     * @return bool
-     */
-    private function validateCountry($value, $country)
-    {
-        $deprecatedOptionsBridge = [
-            'US'            => 'US',
-            'Canada'        => 'CA',
-            'France'        => 'FR',
-            'Netherlands'   => 'NL',
-        ];
-
-        return IsoCodes\ZipCode::validate($value, $deprecatedOptionsBridge[$country]);
     }
 }

--- a/tests/Constraints/ZipCodeTest.php
+++ b/tests/Constraints/ZipCodeTest.php
@@ -19,25 +19,57 @@ class ZipCodeTest extends \PHPUnit_Framework_TestCase
     public function getValidCountries()
     {
         return [
-            ['Canada'],
-            ['France'],
-            ['Netherlands'],
+            ['CA'],
+            ['FR'],
+            ['NL'],
             ['US'],
         ];
     }
 
     /**
+     * 1.0 BC.
+     *
+     * @dataProvider getLegacyValidCountries
+     */
+    public function testLegacyValidCountries($country)
+    {
+        $zipCode = new ZipCode(['country' => $country]);
+
+        // 1.0 BC
+        $deprecatedOptionsBridge = [
+            'Canada'        => 'CA',
+            'France'        => 'FR',
+            'Netherlands'   => 'NL',
+        ];
+
+        $this->assertSame($deprecatedOptionsBridge[$country], $zipCode->country);
+    }
+
+    public function getLegacyValidCountries()
+    {
+        return [
+            ['Canada'],
+            ['France'],
+            ['Netherlands'],
+        ];
+    }
+
+    /**
      * @dataProvider getInvalidCountries
-     * @expectedException Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
     public function testInvalidCountries($country)
     {
-        $zipCode = new ZipCode(['country' => $country]);
+        new ZipCode(['country' => $country]);
     }
 
     public function getInvalidCountries()
     {
         return [
+            ['TL'],
+            [42],
+            ['Liberlands'],
+            // 1.0 BC Test
             ['canada'],
             ['CANADA'],
             ['caNada'],
@@ -47,6 +79,7 @@ class ZipCodeTest extends \PHPUnit_Framework_TestCase
             ['netherlands'],
             ['NETHERLANDS'],
             ['neTherlands'],
+            // END 1.0 BC Test
             ['us'],
             ['uS'],
             ['Us'],

--- a/tests/Constraints/ZipCodeValidatorTest.php
+++ b/tests/Constraints/ZipCodeValidatorTest.php
@@ -33,6 +33,49 @@ class ZipCodeValidatorTest extends AbstractConstraintValidatorTest
     public function getValidValues()
     {
         return [
+            ['A0A 1A0', 'CA'],
+            ['A0A1A0', 'CA'],
+            ['H0H 0H0', 'CA'],
+            ['A0A 1A0', 'CA'],
+            ['06000', 'FR'],
+            ['56000', 'FR'],
+            ['56420', 'FR'],
+            ['20000', 'FR'],
+            ['97114', 'FR'],
+            ['99999', 'FR'],
+            ['99123', 'FR'],
+            ['98000', 'FR'],
+            ['00100', 'FR'],
+            ['01000', 'FR'],
+            ['1234AA', 'NL'],
+            ['1234 AA', 'NL'],
+            ['1023 AA', 'NL'],
+            ['99801', 'US'],
+            ['02115', 'US'],
+            ['10001', 'US'],
+            ['20008', 'US'],
+            ['99950', 'US'],
+        ];
+    }
+
+    /**
+     * 1.0 BC tests.
+     *
+     * @dataProvider getLegacyValidValues
+     */
+    public function testLegacyValidValues($value, $country)
+    {
+        $this->validator->validate($value, new ZipCode([
+            'country' => $country,
+        ]));
+        $this->assertNoViolation();
+        $this->validator->validate($value, new ZipCode());
+        $this->assertNoViolation();
+    }
+
+    public function getLegacyValidValues()
+    {
+        return [
             ['A0A 1A0', 'Canada'],
             ['A0A1A0', 'Canada'],
             ['H0H 0H0', 'Canada'],
@@ -72,6 +115,90 @@ class ZipCodeValidatorTest extends AbstractConstraintValidatorTest
     }
 
     public function getInvalidValues()
+    {
+        return [
+            ['560', 'CA'],
+            ['5600', 'CA'],
+            ['560000', 'CA'],
+            ['A56000', 'CA'],
+            ['A5600', 'CA'],
+            ['56000A', 'CA'],
+            ['A5600A', 'CA'],
+            ['AAA', 'CA'],
+            ['AAAA', 'CA'],
+            ['AAAAA', 'CA'],
+            ['A 0A1A0', 'CA'],
+            ['A0 A1A0', 'CA'],
+            ['A0A1 A0', 'CA'],
+            ['A0A1A 0', 'CA'],
+            ['A0A1a0', 'CA'],
+            ['a0a1a0', 'CA'],
+            ['2A004', 'FR'],
+            ['560', 'FR'],
+            ['5600', 'FR'],
+            ['560000', 'FR'],
+            ['A56000', 'FR'],
+            ['A5600', 'FR'],
+            ['56000A', 'FR'],
+            ['A5600A', 'FR'],
+            ['AAA', 'FR'],
+            ['AAAA', 'FR'],
+            ['AAAAA', 'FR'],
+            ['1234', 'NL'],
+            ['1234A', 'NL'],
+            ['AA1234', 'NL'],
+            ['A1234A', 'NL'],
+            ['1A2A3A', 'NL'],
+            ['1234ABC', 'NL'],
+            ['123AB', 'NL'],
+            ['123456', 'NL'],
+            ['AAAA', 'NL'],
+            ['ABCD12', 'NL'],
+            ['1234 ABC', 'NL'],
+            ['12345A', 'NL'],
+            ['1234 5A', 'NL'],
+            ['0123 AA', 'NL'],
+            ['1234aa', 'NL'],
+            ['5600', 'US'],
+            ['560000', 'US'],
+            ['A56000', 'US'],
+            ['A5600', 'US'],
+            ['56000A', 'US'],
+            ['A5600A', 'US'],
+            ['AAA', 'US'],
+            ['AAAA', 'US'],
+            ['AAAAA', 'US'],
+            ['A 0A1A0', 'US'],
+            ['A0 A1A0', 'US'],
+            ['A0A1 A0', 'US'],
+            ['A0A1A 0', 'US'],
+            ['A0A1a0', 'US'],
+            ['a0a1a0', 'US'],
+            ['AAA', 'all'],
+            ['AAAAA', 'all'],
+            ['Lorem Ipsum', 'all'],
+            ['LOREM IPSUM', 'all'],
+            ['lorem ipsum', 'all'],
+            [' ', 'all'],
+        ];
+    }
+
+    /**
+     * 1.0 BC tests.
+     *
+     * @dataProvider getLegacyInvalidValues
+     */
+    public function testLegacyInvalidValues($value, $country)
+    {
+        $this->validator->validate($value, new ZipCode([
+            'country' => $country,
+        ]));
+
+        $this->buildViolation('This value is not a valid ZIP code.')
+            ->assertRaised();
+    }
+
+    public function getLegacyInvalidValues()
     {
         return [
             ['560', 'Canada'],
@@ -132,7 +259,6 @@ class ZipCodeValidatorTest extends AbstractConstraintValidatorTest
             ['A0A1a0', 'US'],
             ['a0a1a0', 'US'],
             ['AAA', 'all'],
-            ['AAAA', 'all'],
             ['AAAAA', 'all'],
             ['Lorem Ipsum', 'all'],
             ['LOREM IPSUM', 'all'],


### PR DESCRIPTION
Closes #7.

- [x] Implement new options from `IsoCodes` and deprecated old ones.
- [x] Remove BC introduced on 1.0.x on `ZipCodeValidator`
- [x] Adjust / update tests
- [x] Update `UPGRADE-1.1.md`