### PR TITLE
Make Silex 1.2 as a minimum requirement.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="3.0.x-dev as 2.8"
     - php: 5.6
-      env: SILEX_VERSION=1.1.*
-    - php: 5.6
       env: SILEX_VERSION=1.2.*
     - php: 5.6
       env: SILEX_VERSION=1.3.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * 2.0.0 (2015-??-??)
 
  * Make Symfony 2.7 LTS as a minimum requirement.
+ * Make Silex 1.2 as a minimum requirement.
  * Remove deprecated `IsoCodesConstraintValidator` interface.
  * Remove deprecated `ZipCode` country option values.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This version of the project requires:
 * PHP 5.4+
 * Symfony Validator component 2.7+
 * Symfony 2.7+ for bundle integration
-* Silex 1.1+ for service provider integration
+* Silex 1.2+ for service provider integration
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/dependency-injection": "~2.7",
         "symfony/http-kernel": "~2.7",
         "symfony/finder": "~2.7",
-        "silex/silex": "~1.1",
+        "silex/silex": "~1.2",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.4",
         "satooshi/php-coveralls": "~0.6",
         "codeclimate/php-test-reporter": "dev-master",
@@ -36,7 +36,7 @@
         "symfony/dependency-injection": "<2.7",
         "symfony/http-kernel": "<2.7",
         "symfony/finder": "<2.7",
-        "silex/silex": "<1.1.1"
+        "silex/silex": "<1.2"
     },
     "autoload": {
         "psr-4": { "SLLH\\IsoCodesValidator\\": "src" }


### PR DESCRIPTION
Silex 1.1 makes conflict with SF 2.7 dependencies.

See: https://travis-ci.org/Soullivaneuh/IsoCodesValidator/jobs/68622514#L134