### PR TITLE
Remove coverage tools from composer.json

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+src_dir: src

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ cache:
 before_script:
   - composer selfupdate
   - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
-  - composer global require phpunit/phpunit:@stable --no-update
+  - composer global require phpunit/phpunit:@stable satooshi/php-coveralls:@stable codeclimate/php-test-reporter:@stable --no-update
   - composer global update --prefer-dist --no-interaction
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [ "$SILEX_VERSION" != "" ]; then composer require "silex/silex:${SILEX_VERSION}" --no-update; fi;
@@ -59,5 +59,5 @@ before_script:
 script: make test
 
 after_script:
-  - php vendor/bin/coveralls -v
-  - php vendor/bin/test-reporter
+  - coveralls -v
+  - test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,5 +59,5 @@ before_script:
 script: make test
 
 after_script:
-  - coveralls -v
+  - coveralls -c .coveralls.yml -v
   - test-reporter

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,6 @@
         "symfony/finder": "^2.7|^3.0",
         "silex/silex": "^1.2",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.4",
-        "satooshi/php-coveralls": "^0.6",
-        "codeclimate/php-test-reporter": "dev-master",
         "symfony/phpunit-bridge": "^2.7|^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^1.0"
     },


### PR DESCRIPTION
Include it on Travis instead.

This will reduce dependencies conflicts.

#50 could be closed after that since last version of symfony is properly downloaded.