### PR TITLE
Update Symfony versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.7.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev
+      env: SYMFONY_VERSION=2.8.*
     - php: 5.6
-      env: SYMFONY_VERSION="3.0.*@dev"
+      env: SYMFONY_VERSION=3.0.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.1.*@dev
     - php: 5.6
       env: SILEX_VERSION=1.2.*
     - php: 5.6
@@ -38,6 +40,7 @@ matrix:
     - php: hhvm
     - php: hhvm-nightly
     - env: SILEX_VERSION="2.0.x-dev as 1.3"
+    - env: SYMFONY_VERSION=3.1.*@dev
     - env: ISOCODES_VERSION="dev-master"
 
 sudo: false


### PR DESCRIPTION
2.8 and 3.0 are stable now.