### PR TITLE
Introduce ValidatorNotExistsException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
     - php: 5.6
       env: SILEX_VERSION="2.0.x-dev as 1.3"
     - php: 5.6
+      env: ISOCODES_VERSION=2.0.*
+    - php: 5.6
       env: ISOCODES_VERSION=2.1.*
     - php: 5.6
       env: ISOCODES_VERSION="dev-master"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^5.6|^7.0",
         "symfony/validator": "^2.7|^3.0",
         "symfony/translation": "^2.7|^3.0",
-        "ronanguilloux/isocodes": "^2.1"
+        "ronanguilloux/isocodes": "^2.0"
     },
     "require-dev": {
         "symfony/dependency-injection": "^2.7|^3.0",
@@ -23,6 +23,7 @@
         "silex/silex": "^1.2",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.4",
         "symfony/phpunit-bridge": "^2.7|^3.0",
+        "sebastian/exporter": "^1.2.0",
         "sllh/php-cs-fixer-styleci-bridge": "^1.0"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,13 +12,14 @@
          syntaxCheck="false">
     <testsuites>
         <testsuite name="constraints">
-            <directory >./tests/Constraints</directory>
+            <directory>./tests/Constraints</directory>
+            <file>./tests/AbstractIsoCodeGenericConstraintTest.php</file>
         </testsuite>
         <testsuite name="symfony">
-            <directory >./tests/Bundle</directory>
+            <directory>./tests/Bundle</directory>
         </testsuite>
         <testsuite name="silex">
-            <directory >./tests/Provider</directory>
+            <directory>./tests/Provider</directory>
         </testsuite>
     </testsuites>
 

--- a/src/AbstractConstraint.php
+++ b/src/AbstractConstraint.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SLLH\IsoCodesValidator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+abstract class AbstractConstraint extends Constraint implements ConstraintInterface
+{
+}

--- a/src/AbstractIsoCodesConstraintValidator.php
+++ b/src/AbstractIsoCodesConstraintValidator.php
@@ -2,6 +2,9 @@
 
 namespace SLLH\IsoCodesValidator;
 
+use SLLH\IsoCodesValidator\Constraints\IsoCodesGeneric;
+use SLLH\IsoCodesValidator\Constraints\IsoCodesGenericValidator;
+use SLLH\IsoCodesValidator\Exception\ValidatorNotExistsException;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContext;
@@ -27,10 +30,21 @@ abstract class AbstractIsoCodesConstraintValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        $constraintClass = preg_replace('/Validator$/', '', get_class($this));
+        $validatorClass = get_class($this);
+        if (IsoCodesGenericValidator::class === $validatorClass
+            && !($constraint instanceof AbstractIsoCodesGenericConstraint || $constraint instanceof IsoCodesGeneric)
+        ) {
+            throw new UnexpectedTypeException($constraint, AbstractIsoCodesGenericConstraint::class);
+        } elseif (IsoCodesGenericValidator::class !== $validatorClass) {
+            $constraintClass = preg_replace('/Validator$/', '', $validatorClass);
 
-        if (!$constraint instanceof $constraintClass) {
-            throw new UnexpectedTypeException($constraint, $constraintClass);
+            if (!$constraint instanceof $constraintClass) {
+                throw new UnexpectedTypeException($constraint, $constraintClass);
+            }
+        }
+
+        if (!class_exists($constraint->getIsoCodesClass())) {
+            throw new ValidatorNotExistsException($constraint);
         }
     }
 

--- a/src/AbstractIsoCodesGenericConstraint.php
+++ b/src/AbstractIsoCodesGenericConstraint.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SLLH\IsoCodesValidator;
+
+use SLLH\IsoCodesValidator\Constraints\IsoCodesGenericValidator;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+abstract class AbstractIsoCodesGenericConstraint extends AbstractConstraint
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return IsoCodesGenericValidator::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesClass()
+    {
+        $constraintClassTab = explode('\\', get_class($this));
+
+        return 'IsoCodes\\'.end($constraintClassTab);
+    }
+}

--- a/src/ConstraintInterface.php
+++ b/src/ConstraintInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SLLH\IsoCodesValidator;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+interface ConstraintInterface
+{
+    /**
+     * Since which IsoCodes version the class is available?
+     *
+     * @return string
+     */
+    public function getIsoCodesVersion();
+
+    /**
+     * Returns IsoCodes class needed for validation.
+     *
+     * @return string
+     */
+    public function getIsoCodesClass();
+}

--- a/src/Constraints/Bban.php
+++ b/src/Constraints/Bban.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Bban extends IsoCodesGeneric
+final class Bban extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid BBAN.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Cif.php
+++ b/src/Constraints/Cif.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Cif extends IsoCodesGeneric
+final class Cif extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid CIF.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.1.1';
+    }
 }

--- a/src/Constraints/CreditCard.php
+++ b/src/Constraints/CreditCard.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class CreditCard extends IsoCodesGeneric
+final class CreditCard extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid credit card scheme.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Ean13.php
+++ b/src/Constraints/Ean13.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Ean13 extends IsoCodesGeneric
+final class Ean13 extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This EAN 13 code is not valid.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Ean8.php
+++ b/src/Constraints/Ean8.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Ean8 extends IsoCodesGeneric
+final class Ean8 extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This EAN 8 code is not valid.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '2.1.0';
+    }
 }

--- a/src/Constraints/Iban.php
+++ b/src/Constraints/Iban.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Iban extends IsoCodesGeneric
+final class Iban extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid IBAN.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Insee.php
+++ b/src/Constraints/Insee.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Insee extends IsoCodesGeneric
+final class Insee extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This INSEE number is not valid.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Ip.php
+++ b/src/Constraints/Ip.php
@@ -2,7 +2,7 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
+use SLLH\IsoCodesValidator\AbstractConstraint;
 
 /**
  * @Annotation
@@ -10,7 +10,23 @@ use Symfony\Component\Validator\Constraint;
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Ip extends Constraint
+final class Ip extends AbstractConstraint
 {
     public $message = 'This value is not a valid IP address.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesClass()
+    {
+        return \IsoCodes\IP::class;
+    }
 }

--- a/src/Constraints/Isbn.php
+++ b/src/Constraints/Isbn.php
@@ -2,7 +2,7 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
-use Symfony\Component\Validator\Constraint;
+use SLLH\IsoCodesValidator\AbstractConstraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Isbn extends Constraint
+final class Isbn extends AbstractConstraint
 {
     public $message = 'This value is not a valid ISBN.';
     public $type = null;
@@ -34,5 +34,21 @@ final class Isbn extends Constraint
     public function getDefaultOption()
     {
         return 'type';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.2.0';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesClass()
+    {
+        return \IsoCodes\Isbn::class;
     }
 }

--- a/src/Constraints/IsoCodesGeneric.php
+++ b/src/Constraints/IsoCodesGeneric.php
@@ -4,8 +4,12 @@ namespace SLLH\IsoCodesValidator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+@trigger_error('The '.__NAMESPACE__.'\IsoCodesGeneric class is deprecated since version 2.1 and will be removed in 3.0.', E_USER_DEPRECATED);
+
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ *
+ * @deprecated since version 2.1. To be removed in 3.0
  */
 class IsoCodesGeneric extends Constraint
 {

--- a/src/Constraints/Nif.php
+++ b/src/Constraints/Nif.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Nif extends IsoCodesGeneric
+final class Nif extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid NIF.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.1.1';
+    }
 }

--- a/src/Constraints/Siren.php
+++ b/src/Constraints/Siren.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Siren extends IsoCodesGeneric
+final class Siren extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid SIREN.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Siret.php
+++ b/src/Constraints/Siret.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Siret extends IsoCodesGeneric
+final class Siret extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid SIRET.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Ssn.php
+++ b/src/Constraints/Ssn.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Ssn extends IsoCodesGeneric
+final class Ssn extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid SSN.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/StructuredCommunication.php
+++ b/src/Constraints/StructuredCommunication.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class StructuredCommunication extends IsoCodesGeneric
+final class StructuredCommunication extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid structured communication code.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.1.0';
+    }
 }

--- a/src/Constraints/SwiftBic.php
+++ b/src/Constraints/SwiftBic.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class SwiftBic extends IsoCodesGeneric
+final class SwiftBic extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid SWIFT.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Uknin.php
+++ b/src/Constraints/Uknin.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Uknin extends IsoCodesGeneric
+final class Uknin extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid NINO.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/Vat.php
+++ b/src/Constraints/Vat.php
@@ -2,13 +2,23 @@
 
 namespace SLLH\IsoCodesValidator\Constraints;
 
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class Vat extends IsoCodesGeneric
+final class Vat extends AbstractIsoCodesGenericConstraint
 {
     public $message = 'This value is not a valid VAT.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
 }

--- a/src/Constraints/ZipCode.php
+++ b/src/Constraints/ZipCode.php
@@ -3,7 +3,7 @@
 namespace SLLH\IsoCodesValidator\Constraints;
 
 use IsoCodes;
-use Symfony\Component\Validator\Constraint;
+use SLLH\IsoCodesValidator\AbstractConstraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class ZipCode extends Constraint
+final class ZipCode extends AbstractConstraint
 {
     const ALL           = 'all';
 
@@ -33,5 +33,21 @@ final class ZipCode extends Constraint
                 implode('", "', IsoCodes\ZipCode::getAvailableCountries())
             ));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '1.0.0';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesClass()
+    {
+        return IsoCodes\ZipCode::class;
     }
 }

--- a/src/Exception/ValidatorNotExistsException.php
+++ b/src/Exception/ValidatorNotExistsException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SLLH\IsoCodesValidator\Exception;
+
+use SLLH\IsoCodesValidator\ConstraintInterface;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class ValidatorNotExistsException extends \Exception
+{
+    /**
+     * @param ConstraintInterface $constraint
+     * @param \Exception|null     $previous
+     */
+    public function __construct(ConstraintInterface $constraint, \Exception $previous = null)
+    {
+        $message = 'The '.$constraint->getIsoCodesClass().' class does not exist.'
+            .' This class is available since version '.$constraint->getIsoCodesVersion().' of IsoCodes library.'
+            .' Please consider upgrading.';
+
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/tests/AbstractIsoCodeGenericConstraintTest.php
+++ b/tests/AbstractIsoCodeGenericConstraintTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SLLH\IsoCodesValidator\Tests;
+
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+use SLLH\IsoCodesValidator\Constraints\Bban;
+use SLLH\IsoCodesValidator\Constraints\Cif;
+use SLLH\IsoCodesValidator\Constraints\Iban;
+use SLLH\IsoCodesValidator\Constraints\IsoCodesGenericValidator;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class AbstractIsoCodeGenericConstraintTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getGenericConstraints
+     *
+     * @param AbstractIsoCodesGenericConstraint $constraint
+     */
+    public function testValidatorName($constraint)
+    {
+        $this->assertSame(IsoCodesGenericValidator::class, $constraint->validatedBy());
+    }
+
+    public function getGenericConstraints()
+    {
+        return [
+            [new Bban()],
+            [new Cif()],
+            [new Iban()],
+        ];
+    }
+}

--- a/tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/tests/Constraints/AbstractConstraintValidatorTest.php
@@ -2,8 +2,8 @@
 
 namespace SLLH\IsoCodesValidator\Tests\Constraints;
 
+use SLLH\IsoCodesValidator\ConstraintInterface;
 use SLLH\IsoCodesValidator\Constraints\IsoCodesGenericValidator;
-use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Blank;
 use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest as BaseAbstractConstraintValidatorTest;
 use Symfony\Component\Validator\Validation;
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Validation;
 abstract class AbstractConstraintValidatorTest extends BaseAbstractConstraintValidatorTest
 {
     /**
-     * @var Constraint
+     * @var ConstraintInterface
      */
     protected $srcConstraint;
 
@@ -20,6 +20,10 @@ abstract class AbstractConstraintValidatorTest extends BaseAbstractConstraintVal
         parent::setUp();
 
         $this->srcConstraint = $this->createConstraint();
+
+        if (!class_exists($this->srcConstraint->getIsoCodesClass())) {
+            $this->markTestSkipped('The '.$this->srcConstraint->getIsoCodesClass().' validator class does not exists.');
+        }
     }
 
     protected function getApiVersion()
@@ -46,6 +50,20 @@ abstract class AbstractConstraintValidatorTest extends BaseAbstractConstraintVal
         $this->validator->validate('', $this->createConstraint());
 
         $this->assertNoViolation();
+    }
+
+    public function testItImplementsInterface()
+    {
+        $this->assertInstanceOf(ConstraintInterface::class, $this->srcConstraint);
+    }
+
+    public function testItProvidesAnIsoCodesVersion()
+    {
+        $this->assertStringMatchesFormat(
+            '%d.%d.%d',
+            $this->srcConstraint->getIsoCodesVersion(),
+            'You should provide a proper version of IsoCodes library.'
+        );
     }
 
     protected function createValidator()

--- a/tests/Constraints/IsoCodeGenericTest.php
+++ b/tests/Constraints/IsoCodeGenericTest.php
@@ -2,33 +2,31 @@
 
 namespace SLLH\IsoCodesValidator\Tests\Constraints;
 
-use SLLH\IsoCodesValidator\Constraints\Bban;
-use SLLH\IsoCodesValidator\Constraints\Cif;
-use SLLH\IsoCodesValidator\Constraints\Iban;
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
 use SLLH\IsoCodesValidator\Constraints\IsoCodesGeneric;
+use SLLH\IsoCodesValidator\Constraints\IsoCodesGenericValidator;
+use SLLH\IsoCodesValidator\Tests\Fixtures\Constraints\LegacyFake;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ * @group legacy
  */
 class IsoCodeGenericTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @dataProvider getGenericConstraints
+     * @dataProvider getLegacyGenericConstraints
      *
-     * @param IsoCodesGeneric $constraint
-     * @param                 $validatorName
+     * @param IsoCodesGeneric|AbstractIsoCodesGenericConstraint $constraint
      */
-    public function testValidatorName(IsoCodesGeneric $constraint)
+    public function testValidatorName($constraint)
     {
-        $this->assertSame('SLLH\IsoCodesValidator\Constraints\IsoCodesGenericValidator', $constraint->validatedBy());
+        $this->assertSame(IsoCodesGenericValidator::class, $constraint->validatedBy());
     }
 
-    public function getGenericConstraints()
+    public function getLegacyGenericConstraints()
     {
         return [
-            [new Bban()],
-            [new Cif()],
-            [new Iban()],
+            [new LegacyFake()],
         ];
     }
 }

--- a/tests/Constraints/NotExistsValidatorTest.php
+++ b/tests/Constraints/NotExistsValidatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SLLH\IsoCodesValidator\Tests\Constraints;
+
+use SLLH\IsoCodesValidator\Constraints\IsoCodesGenericValidator;
+use SLLH\IsoCodesValidator\Exception\ValidatorNotExistsException;
+use SLLH\IsoCodesValidator\Tests\Fixtures\Constraints\NotExists;
+use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest as BaseAbstractConstraintValidatorTest;
+
+/**
+ * Special validator to test ValidatorNotExistsException.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class NotExistsValidatorTest extends BaseAbstractConstraintValidatorTest
+{
+    public function testExceptionIsThrown()
+    {
+        $constraint = new NotExists();
+
+        $this->expectException(ValidatorNotExistsException::class);
+        $this->expectExceptionMessage('The IsoCodes\NotExists class does not exist.'
+            .' This class is available since version 42.13.37 of IsoCodes library.'
+            .' Please consider upgrading.');
+
+        $this->validator->validate('fake', $constraint);
+    }
+
+    protected function createValidator()
+    {
+        return new IsoCodesGenericValidator();
+    }
+}

--- a/tests/Fixtures/Constraints/LegacyFake.php
+++ b/tests/Fixtures/Constraints/LegacyFake.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SLLH\IsoCodesValidator\Tests\Fixtures\Constraints;
+
+use SLLH\IsoCodesValidator\Constraints\IsoCodesGeneric;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class LegacyFake extends IsoCodesGeneric
+{
+}

--- a/tests/Fixtures/Constraints/NotExists.php
+++ b/tests/Fixtures/Constraints/NotExists.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SLLH\IsoCodesValidator\Tests\Fixtures\Constraints;
+
+use SLLH\IsoCodesValidator\AbstractIsoCodesGenericConstraint;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class NotExists extends AbstractIsoCodesGenericConstraint
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsoCodesVersion()
+    {
+        return '42.13.37';
+    }
+}


### PR DESCRIPTION
Closes #96.

* IsoCodesGeneric constraint class is deprecated in favor of abstraction
* IsoCodes 2.0 is now allowed