### PR TITLE
Launch constraints test suite on Silex and Symfony version targets

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,9 +16,13 @@
             <file>./tests/AbstractIsoCodeGenericConstraintTest.php</file>
         </testsuite>
         <testsuite name="symfony">
+            <directory>./tests/Constraints</directory>
+            <file>./tests/AbstractIsoCodeGenericConstraintTest.php</file>
             <directory>./tests/Bundle</directory>
         </testsuite>
         <testsuite name="silex">
+            <directory>./tests/Constraints</directory>
+            <file>./tests/AbstractIsoCodeGenericConstraintTest.php</file>
             <directory>./tests/Provider</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
This is needed especially for Symfony validator versions tests.