### PR TITLE
Allow failure for HHVM on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
       env: ISOCODES_VERSION="dev-master"
   allow_failures:
     - php: nightly
+    - php: hhvm
     - env: SYMFONY_VERSION=3.1.*@dev
     - env: ISOCODES_VERSION="dev-master"
 


### PR DESCRIPTION
We have to follow IsoCodes configuration.

Ref: https://github.com/ronanguilloux/IsoCodes/issues/103